### PR TITLE
Remove test for warning logs that were never observed during initial …

### DIFF
--- a/homeassistant/components/libre_hardware_monitor/coordinator.py
+++ b/homeassistant/components/libre_hardware_monitor/coordinator.py
@@ -65,24 +65,6 @@ class LibreHardwareMonitorCoordinator(DataUpdateCoordinator[LibreHardwareMonitor
             )
         )
 
-        # update devices created before 2025.10.2 without unique device id
-        if legacy_device_ids := [
-            device_id
-            for device_id in self._previous_devices
-            if config_entry.entry_id not in device_id
-        ]:
-            device_registry = dr.async_get(self.hass)
-            for device_id in legacy_device_ids:
-                if device := device_registry.async_get_device(
-                    identifiers={(DOMAIN, device_id)}
-                ):
-                    device_registry.async_update_device(
-                        device_id=device.id,
-                        new_identifiers={
-                            (DOMAIN, f"{self.config_entry.entry_id}_{device_id}")
-                        },
-                    )
-
     async def _async_update_data(self) -> LibreHardwareMonitorData:
         try:
             lhm_data = await self._api.get_data()
@@ -104,7 +86,6 @@ class LibreHardwareMonitorCoordinator(DataUpdateCoordinator[LibreHardwareMonitor
         scheduled: bool = False,
         raise_on_entry_error: bool = False,
     ) -> None:
-        # we don't expect the computer to be online 24/7 so we don't want to log a connection loss as an error
         await super()._async_refresh(
             False, raise_on_auth_failed, scheduled, raise_on_entry_error
         )
@@ -120,7 +101,6 @@ class LibreHardwareMonitorCoordinator(DataUpdateCoordinator[LibreHardwareMonitor
             return
 
         if self.data is None:
-            # initial update during integration startup
             self._previous_devices = detected_devices  # type: ignore[unreachable]
             return
 

--- a/homeassistant/components/libre_hardware_monitor/sensor.py
+++ b/homeassistant/components/libre_hardware_monitor/sensor.py
@@ -5,16 +5,14 @@ from __future__ import annotations
 from librehardwaremonitor_api.model import LibreHardwareMonitorSensorData
 
 from homeassistant.components.sensor import SensorEntity, SensorStateClass
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import LibreHardwareMonitorCoordinator
+from . import LibreHardwareMonitorConfigEntry, LibreHardwareMonitorCoordinator
 from .const import DOMAIN
 
-# Coordinator is used to centralize the data updates
 PARALLEL_UPDATES = 0
 
 STATE_MIN_VALUE = "min_value"
@@ -23,7 +21,7 @@ STATE_MAX_VALUE = "max_value"
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: LibreHardwareMonitorConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the LibreHardwareMonitor platform."""

--- a/tests/components/libre_hardware_monitor/test_init.py
+++ b/tests/components/libre_hardware_monitor/test_init.py
@@ -1,0 +1,88 @@
+"""Tests for the LibreHardwareMonitor init."""
+
+import logging
+from unittest.mock import AsyncMock
+
+import pytest
+
+from homeassistant.components.libre_hardware_monitor.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import init_integration
+from .conftest import VALID_CONFIG
+
+from tests.common import MockConfigEntry
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@pytest.mark.usefixtures("mock_lhm_client")
+async def test_unique_id_migration(
+    hass: HomeAssistant,
+    mock_lhm_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test migration of entities with old unique ID format."""
+    # Create a new config entry with version 1 to trigger migration
+    config_entry_v1 = MockConfigEntry(
+        domain=DOMAIN,
+        title="192.168.0.20:8085",
+        data=VALID_CONFIG,
+        entry_id="test_entry_id",
+        version=1,
+    )
+
+    # Add the config entry to Home Assistant
+    config_entry_v1.add_to_hass(hass)
+
+    # Use an actual sensor ID from the mock data (without leading slash)
+    actual_sensor_id = "lpc-nct6687d-0-voltage-0"
+
+    # Manually create entity with old unique ID format first
+    old_unique_id = f"lhm-{actual_sensor_id}"
+    entity_id = "sensor.msi_mag_b650m_mortar_wifi_ms_7d76_12v_voltage"
+
+    entity_registry.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        old_unique_id,
+        suggested_object_id="msi_mag_b650m_mortar_wifi_ms_7d76_12v_voltage",
+        config_entry=config_entry_v1,
+    )
+
+    # Verify entity exists with old unique ID
+    assert (
+        entity_registry.async_get_entity_id("sensor", DOMAIN, old_unique_id)
+        == entity_id
+    )
+
+    # Ensure entity registry is synchronized before migration
+    await hass.async_block_till_done()
+
+    # Verify the entity is actually in the registry before migration
+    entity_registry_after = er.async_get(hass)
+    assert (
+        entity_registry_after.async_get_entity_id("sensor", DOMAIN, old_unique_id)
+        == entity_id
+    )
+
+    # Now initialize the integration - this should trigger the migration
+    await init_integration(hass, config_entry_v1)
+
+    # Wait for the integration to fully load
+    await hass.async_block_till_done()
+
+    # Get the entity from registry to verify the migration
+    entity_entry = entity_registry.async_get(entity_id)
+    assert entity_entry is not None, "Entity should exist after migration"
+
+    # Verify that the unique ID has been updated
+    new_unique_id = f"lhm_{config_entry_v1.entry_id}_{actual_sensor_id}"
+    assert entity_entry.unique_id == new_unique_id, (
+        f"Unique ID not migrated: {entity_entry.unique_id}"
+    )
+
+    # Double check that looking up by old ID returns None
+    assert entity_registry.async_get_entity_id("sensor", DOMAIN, old_unique_id) is None


### PR DESCRIPTION
…device setup. Moved migration (tests) to (test)_init.py. Several minor code improvements

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
